### PR TITLE
Spaces

### DIFF
--- a/templates/attribute.template
+++ b/templates/attribute.template
@@ -1,11 +1,11 @@
 <%
 /**
  * Boilerplate attribute
- * 
- * This is the template used when creating attributes 
+ *
+ * This is the template used when creating attributes
  * for models generated through the CLI
  * e.g. `sails generate model foo attrName`
  *
  */
 %>
-		<%= name %>	: { type: '<%= type %>' }
+        <%= name %> : { type: '<%= type %>' }

--- a/templates/model.template
+++ b/templates/model.template
@@ -1,7 +1,7 @@
 <%
 /**
  * Boilerplate model
- * 
+ *
  * This is the template used when generating models via the CLI
  * e.g. `sails generate model foo`
  *
@@ -10,14 +10,14 @@
  * <%= filename %>
  *
  * @description :: TODO: You might write a short summary of how this model works and what it represents here.
- * @docs		:: http://sailsjs.org/#!documentation/models
+ * @docs        :: http://sailsjs.org/#!documentation/models
  */
 
 module.exports = {
 
-	attributes: {
+    attributes: {
 <%= attributes %>
 
-	}
+    }
 
 };


### PR DESCRIPTION
It appears that the primary sails repo generates code with spaces. However, sails-generate-model
appears to use tabs.  The result is this weird mix of tabs and spaces in generated code: [Screen shot](https://www.dropbox.com/s/p915vh6wip9qllx/Screenshot%202014-02-15%2011.59.42.png)

To keep consistency, replace the hard tabs in the templates with spaces. The rest of the code,
that is the non template code, I am indifferent about.