### PR TITLE
Update before.js

### DIFF
--- a/lib/before.js
+++ b/lib/before.js
@@ -77,7 +77,7 @@ module.exports = function(scope, cb) {
   }
 
   // Make sure there aren't duplicates
-  if ((_.uniq(attributes)).length !== attributes.length) {
+  if (_(attributes).pluck('name').uniq().valueOf().length !== attributes.length) {
     return cb.invalid('Duplicate attributes not allowed!');
   }
 


### PR DESCRIPTION
Sails-generate-model wasn't preventing duplicate attributes from being added.  This fixes it.