### PR TITLE
Adding all possible model settings to template files

### DIFF
--- a/templates/attribute.template
+++ b/templates/attribute.template
@@ -7,8 +7,8 @@
  * e.g. `sails generate model foo attrName`
  *
  */
-%>
-<%if (lang === 'js') {%>    <%= name %> : { type: '<%= type %>' }
-<%} else if (lang === 'coffee'){ %>    <%=name%>:
-    type: '<%= type %>'
-<%}%>
+%><% if (lang === 'js') { %>    <%= name %>: {
+      type: '<%= type %>'
+    }<% } else if (lang === 'coffee') { %>
+    <%= name %>:
+      type: '<%= type %>'<% } %>

--- a/templates/model.template
+++ b/templates/model.template
@@ -1,4 +1,5 @@
-<%/**
+<%
+/**
  * Boilerplate model
  *
  * This is the template used when generating models via the CLI
@@ -8,23 +9,92 @@
 %><% if (lang === 'js') { %>/**
  * <%= filename %>
  *
- * @description :: TODO: You might write a short summary of how this model works and what it represents here.
- * @docs        :: http://sailsjs.org/#!/documentation/concepts/ORM/Models.html
+ * @docs http://sailsjs.org/#!/documentation/concepts/ORM/Models.html
  */
-
 module.exports = {
+  // Toggle the automatic definition of a createdAt attribute.
+  // autoCreatedAt: false,
 
-  attributes: {
+  // Toggle the automatic definition of a updatedAt attribute.
+  // autoUpdatedAt: false,
+
+  // Toggle the automatic definition of a primary key. If you turn it off, make
+  // sure you define some attribute as your PK.
+  // autoPK: false,
+
+  // The lowercase unique key for this model, e.g. user.
+  // identity: 'customidentityhere',
+
+  // The global name by which you can access your model (if the globalization of
+  // models is enabled).
+  // globalId: 'CustomGlobalId',
+
+  // Controls whether/how Sails will attempt to automatically rebuild the
+  // tables/collections/sets/etc. in your schema.
+  // Possible values:
+  // - safe: never auto-migrate my database(s). I will do it myself (by hand)
+  // - alter: auto-migrate, but attempt to keep my existing data (experimental)
+  // - drop: wipe/drop ALL my data and rebuild models every time I lift Sails
+  // migrate: 'safe',
+
+  // A flag to toggle schemaless or schema mode in databases that support
+  // schemaless data structures.
+  // schema: true,
+
+  // Define which connection queries will be run on.
+  // connection: 'specify-a-connection-here',
+
+  // Define a custom table name to be used by model queries. Useful to work with
+  // legacy databases.
+  // tableName: 'custom_table_name_here',
+
+  // The most important configuration: your model attributes.
+<% if (attributes.length > 0) { %>  attributes: {
 <%= attributes %>
-  }
+  }<% } else { %>  attributes: {}<% } %>
 };
-<%} else if (lang === 'coffee'){ %> # <%= filename %>
+<%} else if (lang === 'coffee') { %>
+ # <%= filename %>
  #
- # @description :: TODO: You might write a short summary of how this model works and what it represents here.
- # @docs        :: http://sailsjs.org/#!/documentation/concepts/ORM/Models.html
-
+ # @docs http://sailsjs.org/#!/documentation/concepts/ORM/Models.html
 module.exports =
+  # Toggle the automatic definition of a createdAt attribute.
+  # autoCreatedAt: false
 
-<%if (attributes.length > 0){%>  attributes:
-  <%= attributes %>
-<%} else{ %>  attributes: {}<%}%><%}%>
+  # toggle the automatic definition of a updatedAt attribute.
+  # autoUpdatedAt: false
+
+  # Toggle the automatic definition of a primary key. If you turn it off, make
+  # sure you define some attribute as your PK.
+  # autoPK: false
+
+  # The lowercase unique key for this model, e.g. user.
+  # identity: 'customidentityhere'
+
+  # The global name by which you can access your model (if the globalization of
+  # models is enabled).
+  # globalId: 'CustomGlobalId'
+
+  # Controls whether/how Sails will attempt to automatically rebuild the
+  # tables/collections/sets/etc. in your schema.
+  # Possible values:
+  # - safe: never auto-migrate my database(s). I will do it myself (by hand)
+  # - alter: auto-migrate, but attempt to keep my existing data (experimental)
+  # - drop: wipe/drop ALL my data and rebuild models every time I lift Sails
+  # migrate: 'safe'
+
+  # A flag to toggle schemaless or schema mode in databases that support
+  # schemaless data structures.
+  # schema: true
+
+  # Define which connection queries will be run on.
+  # connection: 'specify-a-connection-here'
+
+  # Define a custom table name to be used by model queries. Useful to work with
+  # legacy databases.
+  # tableName: 'custom_table_name_here'
+
+  # The most important configuration: your model attributes.
+<%if (attributes.length > 0) { %>  attributes:
+<%= attributes %>
+<%} else { %>  attributes: {}<% } %><% } %>


### PR DESCRIPTION
I've added all possible model settings to template files as comments, alongside small descriptions. This would be really useful for beginner developers jumping on Sails.js, as well as experienced developers that needs to check documentation pages to define that specific setting to change a specific behavior of Sails but can't remember the name.

I tried to fix the identation style used in the generated template (I could understand why it was horrible, the problem is that horrible template engine which makes me spend three hours trying to reach a perfect output with a horrible test setup). I couldn't figure out how to force the CoffeeScript output, so I couldn't test it - but I *believe* its working.

Also, I removed the @description that contains a TODO, since there's no need, and IDEs that provide support for TODO comments (I can't believe there are people that still use it, but there are) will get filled with unmeaning TODO entries. That's not good.

I'm bundling multiple changes into one PR but since it does not add/change/remove functionality and, in practice, I'm just inserting documentation on comments, I though it would be a waste of time if I split these changes on some PRs.